### PR TITLE
Containerize server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,85 @@
+ARG ELIXIR_VERSION=1.15.0
+ARG OTP_VERSION=26.0.2
+ARG DEBIAN_VERSION=bullseye-20230612-slim
+
+ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
+ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"
+
+FROM rust as rust
+
+FROM ${BUILDER_IMAGE} as builder
+COPY --from=rust /usr/local/cargo /usr/local/cargo
+ENV PATH=$PATH:/usr/local/cargo/bin
+# install build dependencies
+RUN apt-get update -y && apt-get install -y build-essential git wget \
+    && apt-get clean && rm -f /var/lib/apt/lists/*_*
+
+# prepare build dir
+WORKDIR /app
+
+# install hex + rebar
+RUN mix local.hex --force && \
+    mix local.rebar --force
+
+# set build ENV
+ENV MIX_ENV="prod"
+ENV BUMBLEBEE_CACHE_DIR="/app/.bumblebee"
+
+# install mix dependencies
+COPY mix.exs mix.lock ./
+RUN mix deps.get --only $MIX_ENV
+RUN mkdir config
+
+# copy compile-time config files before we compile dependencies
+# to ensure any relevant config change will trigger the dependencies
+# to be re-compiled.
+COPY config/config.exs config/${MIX_ENV}.exs config/
+RUN rustup default stable && mix deps.compile
+
+COPY priv priv
+
+COPY lib lib
+
+# Compile the release
+RUN  mix compile
+
+# Changes to config/runtime.exs don't require recompiling the code
+COPY config/runtime.exs config/
+
+COPY rel rel
+RUN mix release
+
+# start a new build stage so that the final image will only contain
+# the compiled release and other runtime necessities
+FROM ${RUNNER_IMAGE}
+
+ENV ELEVEN_LABS_MODEL_ID="eleven_turbo_v2"
+ENV ELEVEN_LABS_VOICE_ID="21m00Tcm4TlvDq8ikWAM"
+ENV ELEVEN_LABS_OPTIMIZE_STREAMING_LATENCY=2
+ENV ELEVEN_LABS_OUTPUT_FORMAT="mp3_22050_32"
+
+RUN apt-get update -y && apt-get install -y libstdc++6 openssl libncurses5 locales ca-certificates \
+    && apt-get clean && rm -f /var/lib/apt/lists/*_*
+
+# Set the locale
+RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+EXPOSE 4000
+
+WORKDIR "/app"
+RUN chown nobody /app
+
+# set runner ENV
+ENV MIX_ENV="prod"
+ENV BUMBLEBEE_CACHE_DIR="/app/.bumblebee"
+
+# Only copy the final release from the build stage
+COPY --from=builder --chown=nobody:root /app/_build/${MIX_ENV}/rel/echo ./
+
+USER nobody
+
+CMD ["/app/bin/server"]

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -25,7 +25,8 @@ config :echo, Echo.Client.ElevenLabs.WebSocket,
   voice_id: System.get_env("ELEVEN_LABS_VOICE_ID") || "21m00Tcm4TlvDq8ikWAM",
   model_id: System.get_env("ELEVEN_LABS_MODEL_ID") || "eleven_turbo_v2",
   optimize_streaming_latency: System.get_env("ELEVEN_LABS_OPTIMIZE_STREAMING_LATENCY") || 2,
-  output_format: System.get_env("ELEVEN_LABS_OUTPUT_FORMAT") || "pcm_44100"
+  # default to mp3 since PCM is paywalled
+  output_format: System.get_env("ELEVEN_LABS_OUTPUT_FORMAT") || "mp3_22050_32"
 
 config :nx, default_backend: EXLA.Backend
 
@@ -49,7 +50,7 @@ if config_env() == :prod do
   port = String.to_integer(System.get_env("PORT") || "4000")
 
   config :echo, EchoWeb.Endpoint,
-    http: [ip: {127, 0, 0, 1}, port: port],
+    http: [ip: {0, 0, 0, 0}, port: port],
     server: true,
     code_reloader: false,
     check_origin: false,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -25,7 +25,6 @@ config :echo, Echo.Client.ElevenLabs.WebSocket,
   voice_id: System.get_env("ELEVEN_LABS_VOICE_ID") || "21m00Tcm4TlvDq8ikWAM",
   model_id: System.get_env("ELEVEN_LABS_MODEL_ID") || "eleven_turbo_v2",
   optimize_streaming_latency: System.get_env("ELEVEN_LABS_OPTIMIZE_STREAMING_LATENCY") || 2,
-  # default to mp3 since PCM is paywalled
   output_format: System.get_env("ELEVEN_LABS_OUTPUT_FORMAT") || "mp3_22050_32"
 
 config :nx, default_backend: EXLA.Backend

--- a/lib/echo/vad.ex
+++ b/lib/echo/vad.ex
@@ -5,7 +5,6 @@ defmodule Echo.VAD do
   Ideally, we would use Nx.Serving here, but unfortunately it does
   not currently support custom batch dimensions.
   """
-  @model_path Path.join([:code.priv_dir(:echo), "models", "silero_vad.onnx"])
   @sample_rate 16_000
 
   @threshold 0.5
@@ -26,7 +25,7 @@ defmodule Echo.VAD do
 
   @impl true
   def init(_opts) do
-    model = Ortex.load(@model_path)
+    model = Ortex.load(Path.join([:code.priv_dir(:echo), "models", "silero_vad.onnx"]))
 
     {:ok,
      %{

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Echo.MixProject do
     [
       app: :echo,
       version: "0.1.0",
-      elixir: "~> 1.14",
+      elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),


### PR DESCRIPTION
Adds a Dockerfile for containerizing the server. Includes the following changes:
* Sets default eleven labs audio type to MP3 since most people will not have the paid plan to support PCM audio
* Adds Dockerfile
* Separate `Usage` section of `README` into `Development Server` and `Docker Deployment` sections. The previous contents of `Usage` are now in the `Development Server` section, and I added the docs relevant to building and running the `Dockerfile`
* Makes the VAD model's path determined at runtime, since `:code.priv_dir` changes what it points to depending on runtime vs. comptime during a production release
* Changes the minimum Elixir version to `1.15.0` to reflect the requirement of `URI.append_path` which is since `1.15.0`